### PR TITLE
Create Alchemy.lua

### DIFF
--- a/Libs/LibLazyCrafting/Alchemy.lua
+++ b/Libs/LibLazyCrafting/Alchemy.lua
@@ -49,14 +49,13 @@ end
 --
 local function LLC_FindSlotsContaining(itemLink)
 	local wantItemName = GetItemLinkName(itemLink)
-	local wantQuality = GetItemLinkQuality(itemLink)
 
 	local r = {}
 	local bagId = BAG_BACKPACK
 	local maxSlotId = GetBagSize(bagId)
-	for slotIndex = 1, maxSlotId do
+	for slotIndex = 0, maxSlotId do
 		local slotLink = GetItemLink(bagId, slotIndex, LINK_STYLE_DEFAULT)
-		if GetItemLinkName(slotLink) == wantItemName and GetItemLinkQuality(slotLink) == wantQuality then
+		if GetItemLinkName(slotLink) == wantItemName then
 			r[slotIndex] = GetSlotStackSize(bagId, slotIndex)
 		end
 	end
@@ -97,7 +96,7 @@ local function LLC_AlchemyCraftInteraction(event, station)
 		reagent2BagId, reagent2SlotIndex,
 		reagent3BagId, reagent3SlotIndex,
 	}
-	if not (solventSlotIndex and reagent1SlotIndex and reagent2SlotIndex) then return end
+	if not (solventSlotIndex and reagent1SlotIndex and reagent2SlotIndex and (not earliest["reagentId3"] or reagent3SlotIndex)) then return end
 
 	dbug("CALL:ZOAlchemyCraft")
 	CraftAlchemyItem(unpack(locations))

--- a/Libs/LibLazyCrafting/Alchemy.lua
+++ b/Libs/LibLazyCrafting/Alchemy.lua
@@ -6,12 +6,13 @@ local function dbug(...)
 	DolgubonGlobalDebugOutput(...)
 end
 
-local function LLC_CraftAlchemy(self, solventId, reagentId1, reagentId2, reagentId3, autocraft, reference)
+local function LLC_CraftAlchemyPotionItemByItemId(self, solventId, reagentId1, reagentId2, reagentId3, timesToMake, autocraft, reference)
 	dbug('FUNCTION:LLCCraftAlchemy')
 	if reference == nil then reference = "" end
 	if not self then d("Please call with colon notation") end
 	if autocraft==nil then autocraft = self.autocraft end
 	if not solventId and reagentId1 and reagentId2 then return end -- reagentId3 optional, nil okay.
+	if timesToMake == nil then timesToMake = 1 end
 
 	table.insert(craftingQueue[self.addonName][CRAFTING_TYPE_ALCHEMY],
 	{
@@ -24,6 +25,7 @@ local function LLC_CraftAlchemy(self, solventId, reagentId1, reagentId2, reagent
 		["Requester"] = self.addonName,
 		["reference"] = reference,
 		["station"] = CRAFTING_TYPE_ALCHEMY,
+		["timesToMake"] = timesToMake,
 	}
 	)
 
@@ -31,6 +33,16 @@ local function LLC_CraftAlchemy(self, solventId, reagentId1, reagentId2, reagent
 	if GetCraftingInteractionType()==CRAFTING_TYPE_ALCHEMY then
 		LibLazyCrafting.craftInteract(event, CRAFTING_TYPE_ALCHEMY)
 	end
+end
+
+local function LLC_CraftAlchemyItem(self, selventBagId, solventSlotId, reagent1BagId, reagent1SlotId, reagent2BagId, reagent2SlotId, reagent3BagId, reagent3SlotId, timesToMake, autocraft, reference)
+	local reagent3itemId
+	if reagent3SlotId==nil then
+		reagent3itemId = nil
+	else
+		reagent3itemId = GetItemId(reagent3BagId, reagent3SlotId)
+	end
+	LLC_CraftEnchantingGlyphItemID(self, GetItemId(selventBagId, solventSlotId),GetItemId( reagent1BagId, reagent1SlotId),GetItemId(reagent2BagId, reagent2SlotId), reagent3itemId, timesToMake,autocraft, reference)
 end
 
 local function copy(t)
@@ -135,20 +147,27 @@ local function LLC_AlchemyCraftingComplete(event, station, lastCheck)
 	local newSlots = LLC_FindSlotsContaining(currentCraftAttempt.link)
 	local grewSlotIndex = LLC_FindIncreasedSlotIndex(currentCraftAttempt.prevSlots, newSlots)
 	if grewSlotIndex then
-		dbug("ACTION:RemoveQueueItem")
-		craftingQueue[currentCraftAttempt.addon][CRAFTING_TYPE_ALCHEMY][currentCraftAttempt.position] = nil
-		sortCraftQueue()
-		local resultTable =
-		{
-			["bag"] = BAG_BACKPACK,
-			["slot"] = grewSlotIndex,
-			['link'] = currentCraftAttempt.link,
-			['uniqueId'] = GetItemUniqueId(BAG_BACKPACK, currentCraftAttempt.slot),
-			["quantity"] = 1,
-			["reference"] = currentCraftAttempt.reference,
-		}
-		currentCraftAttempt.callback(LLC_CRAFT_SUCCESS, CRAFTING_TYPE_ALCHEMY, resultTable)
-		currentCraftAttempt = {}
+		dbug("RESULT:PotionMade")
+		if currentCraftAttempt["timesToMake"] < 2 then
+			dbug("ACTION:RemoveQueueItem")
+			craftingQueue[currentCraftAttempt.addon][CRAFTING_TYPE_ALCHEMY][currentCraftAttempt.position] = nil
+			sortCraftQueue()
+			local resultTable =
+			{
+				["bag"] = BAG_BACKPACK,
+				["slot"] = grewSlotIndex,
+				['link'] = currentCraftAttempt.link,
+				['uniqueId'] = GetItemUniqueId(BAG_BACKPACK, currentCraftAttempt.slot),
+				["quantity"] = 1,
+				["reference"] = currentCraftAttempt.reference,
+			}
+
+			currentCraftAttempt.callback(LLC_CRAFT_SUCCESS, CRAFTING_TYPE_ALCHEMY, resultTable)
+			currentCraftAttempt = {}
+		else
+			craftingQueue[currentCraftAttempt.addon][CRAFTING_TYPE_ALCHEMY][currentCraftAttempt.position]["timesToMake"] = craftingQueue[currentCraftAttempt.addon][CRAFTING_TYPE_ALCHEMY][currentCraftAttempt.position]["timesToMake"] - 1
+			if GetCraftingInteractionType()==0 then zo_callLater(function() LLC_EnchantingCraftingComplete(event, station, true) end,100) end
+		end
 
 	elseif lastCheck then
 
@@ -172,4 +191,5 @@ LibLazyCrafting.craftInteractionTables[CRAFTING_TYPE_ALCHEMY] =
 	["isItemCraftable"] = function(station) if station == CRAFTING_TYPE_ALCHEMY then return true else return false end end,
 }
 
-LibLazyCrafting.functionTable.CraftAlchemy = LLC_CraftAlchemy
+LibLazyCrafting.functionTable.CraftAlchemyItem = LLC_CraftAlchemyItem
+LibLazyCrafting.functionTable.CraftAlchemyItemByItemId = LLC_CraftAlchemyItemByItemId

--- a/Libs/LibLazyCrafting/Provisioning.lua
+++ b/Libs/LibLazyCrafting/Provisioning.lua
@@ -1,0 +1,78 @@
+local LibLazyCrafting = LibStub("LibLazyCrafting")
+local sortCraftQueue = LibLazyCrafting.sortCraftQueue
+
+local function dbug(...)
+    if not DolgubonGlobalDebugOutput then return end
+    DolgubonGlobalDebugOutput(...)
+end
+
+local function toRecipeLink(recipeId)
+    return string.format("|H1:item:%s:3:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h|h", tostring(recipeId))
+end
+
+local function LLC_CraftProvisioningItemByRecipeId(self, recipeId, timesToMake, autocraft, reference)
+    dbug('FUNCTION:LLCCraftProvisioning')
+    if reference == nil then reference = "" end
+    if not self then d("Please call with colon notation") end
+    if autocraft==nil then autocraft = self.autocraft end
+    if not recipeId then return end
+
+    -- ZOS API prefers recipeListIndex + recipeIndex, not recipeId or recipeLink.
+    -- Translate now, fail silently if we cannot.
+    local recipeLink = toRecipeLink(recipeId)
+    local recipeListIndex, recipeIndex = GetItemLinkGrantedRecipeIndices(recipeLink)
+    if not (recipeListIndex and recipeIndex) then return end
+
+    table.insert(craftingQueue[self.addonName][CRAFTING_TYPE_PROVISIONING],
+    {
+        ["recipeId"] = recipeId,
+        ["recipeListIndex"] = recipeListIndex,
+        ["recipeIndex"] = recipeIndex,
+        ["timestamp"] = GetTimeStamp(),
+        ["autocraft"] = autocraft,
+        ["Requester"] = self.addonName,
+        ["reference"] = reference,
+        ["station"] = CRAFTING_TYPE_PROVISIONING,
+        ["timesToMake"] = timesToMake or 1
+    }
+    )
+
+    sortCraftQueue()
+    if GetCraftingInteractionType()==CRAFTING_TYPE_PROVISIONING then
+        LibLazyCrafting.craftInteract(event, CRAFTING_TYPE_PROVISIONING)
+    end
+end
+
+local function LLC_ProvisioningCraftInteraction(event, station)
+    dbug("FUNCTION:LLCProvisioningCraft")
+    local earliest, addon , position = LibLazyCrafting.findEarliestRequest(CRAFTING_TYPE_PROVISIONING)
+    if (not earliest) or IsPerformingCraftProcess() then return end
+
+    dbug("CALL:ZOProvisioningCraft")
+    local recipeArgs = { earliest.recipeListIndex, earliest.recipeIndex }
+    CraftProvisionerItem(unpack(recipeArgs))
+
+    currentCraftAttempt = LibLazyCrafting.tableShallowCopy(earliest)
+    currentCraftAttempt.callback = LibLazyCrafting.craftResultFunctions[addon]
+    currentCraftAttempt.slot = nil
+    currentCraftAttempt.link = GetRecipeResultItemLink(unpack(recipeArgs))
+    currentCraftAttempt.position = position
+    currentCraftAttempt.timestamp = GetTimeStamp()
+    currentCraftAttempt.addon = addon
+    currentCraftAttempt.prevSlots = LibLazyCrafting.findSlotsContaining(currentCraftAttempt.link)
+end
+
+local function LLC_ProvisioningCraftingComplete(event, station, lastCheck)
+    LibLazyCrafting.stackableCraftingComplete(event, station, lastCheck, CRAFTING_TYPE_PROVISIONING, currentCraftAttempt)
+end
+
+LibLazyCrafting.craftInteractionTables[CRAFTING_TYPE_PROVISIONING] =
+{
+    ["check"] = function(station) return station == CRAFTING_TYPE_PROVISIONING end,
+    ['function'] = LLC_ProvisioningCraftInteraction,
+    ["complete"] = LLC_ProvisioningCraftingComplete,
+    ["endInteraction"] = function(station) --[[endInteraction()]] end,
+    ["isItemCraftable"] = function(station) if station == CRAFTING_TYPE_PROVISIONING then return true else return false end end,
+}
+
+LibLazyCrafting.functionTable.CraftProvisioningItemByRecipeId = LLC_CraftProvisioningItemByRecipeId


### PR DESCRIPTION
 - Slot Indexes start at 0, not 1. I know, it's lua, and that's odd.
 - Quality is irrelevant for potions.
 - You can have Essence of Health that's dropped. It can also be crafted with just a health effect, or crafted with up to three effects. That info is contained in the item link. We have a few options. We can use GetItemLinkTraitOnUseAbilityInfo(string itemLink, number index), and compare the returns from that. We could also directly compare the relevant fields of the item link, (which I believe is the 1st,2nd,3rd numbers, and the last number. More testing would be needed though, and as it's not actually that important that it isaccurate, it's probably not worth it to do.
 - local reagent3BagId, reagent3SlotIndex = nil, nil is not necessary, you can do just local reagent3BagId, reagent3SlotIndex. I left it like that in case it's a stylistic preference.
 - If a third reagent is provided and asked for, then we should also have a slotID for that. If we don't, we're not going to give the user/addon what they asked for. Line 99