### PR TITLE
Added maxCraftableVoucherCost to default settings table

### DIFF
--- a/WritWorthy.lua
+++ b/WritWorthy.lua
@@ -13,7 +13,9 @@ WritWorthy.savedVarVersion = 1
 
 WritWorthy.default = {
                         -- UI topleft, used by WritWorthyInventoryList.
-    position = { 50, 50 }
+    position = { 50, 50 },
+                        -- Maximum per voucher cost to craft
+    maxCraftableVoucherCost = 1500, 
 }
                         -- Default savedChariables: per-character saved data.
                         -- Initially just data about that character's inventory.

--- a/WritWorthy.xml
+++ b/WritWorthy.xml
@@ -84,7 +84,7 @@
           <Textures
               normal="EsoUI/Art/Help/help_tabicon_feedback_up.dds"
               pressed="EsoUI/Art/Help/help_tabicon_feedback_down.dds"
-              mouseOver="EsoUI/Art/Help/help_tabicon_feedback_mouseOver.dds"
+              mouseOver="EsoUI/Art/Help/help_tabicon_feedback_over.dds"
               disabled="EsoUI/Art/Help/help_tabicon_feedback_disabled.dds"
               />
           <Anchor relativeTo="$(parent)"
@@ -116,7 +116,55 @@
             WritWorthyInventoryList_SortByStation()
           </OnClicked>
         </Button>
+        <Control name="$(parent)VoucherCost" >
+          <Dimensions width="200"/>
+          <Anchor point="RIGHT" 
+            relativeTo="$(parent)SortByStation" 
+            relativePoint="LEFT" 
+            offsetX="-50" 
+            offsetY="0" />
+          <Controls>
+            <Backdrop name="$(parent)Backdrop" tier="HIGH" inherits="ZO_EditBackdrop">
+              <Dimensions x="50"/>
+              <Anchor point="LEFT" 
+                relativeTo="$(parent)" 
+                relativePoint="RIGHT" 
+                offsetX="0" />
+              <Controls>
+                <EditBox name="$(parent)Edit" 
+                  inherits="ZO_DefaultEditForBackdrop ZO_EditDefaultText" 
+                  textType="NUMERIC_UNSIGNED_INT" 
+                  maxInputCharacters="4">
 
+                  <OnInitialized>
+                    ZO_EditDefaultText_Initialize(self, "")
+                  </OnInitialized>
+                  <OnTextChanged>
+                    local newMax = tonumber(self:GetText())
+                    if newMax then
+                     WritWorthy.savedVariables.maxCraftableVoucherCost = newMax
+                     WritWorthyUI_RefreshUI()
+                    else
+                     WritWorthy.savedVariables.maxCraftableVoucherCost = 0
+                     WritWorthyUI_RefreshUI()
+                    end
+                  </OnTextChanged>
+                </EditBox>
+              </Controls>
+            </Backdrop>
+
+            <Label name="$(parent)Label"  
+              text="Max Voucher Cost:" 
+              color="FFFFFF" 
+              font="ZoFontGameLargeBold">
+              <Anchor point="RIGHT" 
+                relativeTo="$(parent)Backdrop" 
+                relativePoint="LEFT" 
+                offsetX="-10" />
+              
+            </Label>
+          </Controls>
+        </Control>
                           <!-- WritWorthyUIInventoryList -->
         <Control name="$(parent)InventoryList"
             inheritAlpha="true"

--- a/WritWorthy_Window.lua
+++ b/WritWorthy_Window.lua
@@ -682,6 +682,13 @@ function WritWorthyInventoryList:CanQueue(inventory_data)
         and inventory_data.parser.request_item.school.autocraft_not_implemented then
         return false, "WritWorthy not yet implemented: jewelry crafting."
     end
+    local voucher_ct = WritWorthy.ToVoucherCount(inventory_data.item_link)
+    local mat_list = inventory_data.parser:ToMatList()
+    local mat_gold = WritWorthy.MatRow.ListTotal(mat_list) or 0
+    -- Is it below the maximum allowed cost per voucher
+    if WritWorthy.savedVariables.maxCraftableVoucherCost < mat_gold/voucher_ct then
+        return false, 'This writ has a high per voucher cost'
+    end
     local text_list = {}
     if inventory_data.parser.ToKnowList then
         for _, know in ipairs(inventory_data.parser:ToKnowList()) do


### PR DESCRIPTION
Added a check of max voucher cost to WritWorthyInventoryList:CanQueue
Added a label and edit box to the xml file for entering max voucher cost
Fixed the incorrect mouse over texture path for the refresh button

New Edit box and label:
![image](https://user-images.githubusercontent.com/16911759/68064517-099c4700-fcf3-11e9-92fd-5fea7fe7dc5e.png)
